### PR TITLE
feat: update to Minecraft 26.2

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -21,8 +21,8 @@
     "disconnect-packet-fix.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.18.5",
-    "minecraft": "~26.1",
+    "fabricloader": ">=0.19.3",
+    "minecraft": "~26.2",
     "java": ">=25",
     "fabric-api": "*"
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,19 +4,19 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=false
 
 # Mod properties
-mod_version = 2.1.1
+mod_version = 2.2.0
 maven_group = dev.ascpixi.dpf
 archives_name = disconnect-packet-fix
 
 # Minecraft properties
-minecraft_version = 26.1
-minecraft_version_range = [26.1]
+minecraft_version = 26.2
+minecraft_version_range = [26.2]
 
 # Fabric
 loom_version = 1.15-SNAPSHOT
-fabric_loader_version = 0.18.5
-fabric_api_version = 0.144.3+26.1
+fabric_loader_version = 0.19.3
+fabric_api_version = 0.153.0+26.2
 
 # NeoForge
 neoforge_moddev_version = 2.0.141
-neoforge_version = 26.1.0.15-beta
+neoforge_version = 26.2.0.7-beta

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -14,14 +14,14 @@ logoFile = "META-INF/icon.png"
 [[dependencies.disconnect_packet_fix]]
 modId = "neoforge"
 type = "required"
-versionRange = "[26.1.0.15-beta,)"
+versionRange = "[26.2.0.7-beta,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.disconnect_packet_fix]]
 modId = "minecraft"
 type = "required"
-versionRange = "[26.1,27.0)"
+versionRange = "[26.2,27.0)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Adds support for MC 26.2 (MC-271325 still unfixed by Mojang, so the workaround is still needed).

- minecraft_version → 26.2
- Fabric: loader 0.19.3, API 0.153.0+26.2
- NeoForge: 26.2.0.7-beta
- Updated dependency ranges; mod_version → 2.2.0

No source changes needed, both Fabric and NeoForge jars build cleanly.